### PR TITLE
Decoupling GRPC server and client

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -17,12 +17,15 @@ import (
 	"google.golang.org/grpc"
 )
 
-var useLocal = flag.Bool("L", false, "use localhost as the only Docker Host")
+var (
+	useLocal       = flag.Bool("L", false, "use localhost as the only Docker Host")
+	serverEndpoint = flag.String("s", constants.LocalIP, "endpoint of the GRPC server")
+)
 
 func main() {
 	flag.Parse()
 
-	conn, err := grpc.Dial("localhost"+constants.ServerPort, grpc.WithInsecure())
+	conn, err := grpc.Dial(*serverEndpoint+constants.ServerPort, grpc.WithInsecure())
 	defer conn.Close()
 	if err != nil {
 		panic(err.Error())
@@ -90,10 +93,9 @@ func readConfiguration() *types.Config {
 
 func configForLocalEnv() *types.Config {
 	host, _ := os.Hostname()
-	const localIP = "0.0.0.0"
 	return &types.Config{
 		Hosts: []types.Host{
-			types.Host{Name: host, IP: localIP},
+			types.Host{Name: host, IP: constants.LocalIP},
 		},
 	}
 }

--- a/client/templates/content/host.html
+++ b/client/templates/content/host.html
@@ -216,7 +216,7 @@
     window.onload = () => {
 
       if (window["WebSocket"]) {
-        conn = new WebSocket("ws://localhost:8000/ws");
+        conn = new WebSocket("ws://localhost:7585/ws");
 
         conn.onopen = () => {}
         

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -7,6 +7,9 @@ const (
 	ServerNetwork = "tcp"
 )
 
+// LocalIP is the IP address of the localhost
+const LocalIP = "0.0.0.0"
+
 // DockerAPIPort is the default TCP port on each host, at which Docker should be listening for TCP requests
 const DockerAPIPort = ":2375"
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,9 +1,10 @@
 package constants
 
-// Host ports for web client and gRPC server
+// Host ports and network for web client and GRPC server
 const (
-	ClientPort = ":8000"
-	ServerPort = ":5000"
+	ClientPort    = ":7585"
+	ServerPort    = ":7584"
+	ServerNetwork = "tcp"
 )
 
 // DockerAPIPort is the default TCP port on each host, at which Docker should be listening for TCP requests

--- a/server/main.go
+++ b/server/main.go
@@ -4,18 +4,14 @@ import (
 	"log"
 	"net"
 
+	"github.com/gauravgahlot/dockerdoodle/constants"
 	"github.com/gauravgahlot/dockerdoodle/pb"
 	"github.com/gauravgahlot/dockerdoodle/server/services"
 	"google.golang.org/grpc"
 )
 
-const (
-	port    = ":5000"
-	network = "tcp"
-)
-
 func main() {
-	lis, err := net.Listen(network, port)
+	lis, err := net.Listen(constants.ServerNetwork, constants.ServerPort)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -24,7 +20,7 @@ func main() {
 	// register services with gRPC server
 	registerServices(server)
 
-	log.Println("Server listening at port", port)
+	log.Println("Server listening at port", constants.ServerPort)
 	server.Serve(lis)
 }
 


### PR DESCRIPTION
- added **L** flag to use localhost as the only Docker host
- added **s** flag to receive GRPC server endpoint
- updated ports in constants